### PR TITLE
Track TH changes in GHC 7.9

### DIFF
--- a/Language/Haskell/Convert.hs
+++ b/Language/Haskell/Convert.hs
@@ -248,6 +248,7 @@ instance Convert TH.Kind HS.Kind where
     conv (AppT (AppT ArrowT x) y) = KindFn (c x) (c y)
 #endif
 
+#if __GLASGOW_HASKELL__ < 709
 instance Convert TH.Pred HS.Asst where
     conv (ClassP x y) = ClassA (UnQual $ c x) $ c y
     conv (TH.EqualP x y) = HS.EqualP (c x) $ c y
@@ -255,6 +256,7 @@ instance Convert TH.Pred HS.Asst where
 instance Convert HS.Asst TH.Pred where
     conv (ClassA x y) = ClassP (c x) $ c y
     conv (HS.EqualP x y) = TH.EqualP (c x) $ c y
+#endif
 
 instance Convert HS.TyVarBind TH.TyVarBndr where
     conv (UnkindedVar x) = PlainTV $ c x

--- a/Language/Haskell/TH/Compat.hs
+++ b/Language/Haskell/TH/Compat.hs
@@ -25,8 +25,7 @@ dataDefinitionTypeArgs (DataD _cx name args cons _derv) = args
 dataDefinitionTypeArgs (NewtypeD cx name args con derv) = args
 #endif
 
-
-#if __GLASGOW_HASKELL__ >= 612
+#if __GLASGOW_HASKELL__ >= 612 && __GLASGOW_HASKELL__ < 709
 typeToPred :: Type -> Pred
 typeToPred (ConT v) = ClassP v []
 typeToPred (AppT x y) = ClassP v (t++[y])

--- a/Language/Haskell/TH/FixedPpr.hs
+++ b/Language/Haskell/TH/FixedPpr.hs
@@ -405,8 +405,10 @@ instance Ppr Kind where
     ppr (ArrowK j k) = ppr j <+> text "->" <+> ppr k
 #endif
 
+#if __GLASGOW_HASKELL__ < 709
 instance Ppr Pred where
     ppr (ClassP n ts) = ppr n <+> hsep (map ppr ts)
     ppr (EqualP t u ) = ppr t <+> text "~" <+> ppr u
+#endif
 
 #endif


### PR DESCRIPTION
While it compiles with 7.6.3 and 7.9, I have no idea if this does what it's meant to. With both compilers, `ghci Main.hs`, `:main --generate`, `:reload`, `main --test` just gives me

```
Derive/TestInstances.hs:28:10:
    No instance for (GBinary (GHC.Generics.Rep (a -> b)))
      arising from a use of ‘binary-0.7.1.0:Data.Binary.Class.$gdmput’
    In the expression: (binary-0.7.1.0:Data.Binary.Class.$gdmput)
    In an equation for ‘put’:
        put = (binary-0.7.1.0:Data.Binary.Class.$gdmput)
    In the instance declaration for ‘Binary (a -> b)’

Derive/TestInstances.hs:28:10:
    No instance for (GBinary (GHC.Generics.Rep (a -> b)))
      arising from a use of ‘binary-0.7.1.0:Data.Binary.Class.$gdmget’
    In the expression: (binary-0.7.1.0:Data.Binary.Class.$gdmget)
    In an equation for ‘get’:
        get = (binary-0.7.1.0:Data.Binary.Class.$gdmget)
    In the instance declaration for ‘Binary (a -> b)’
```

This seems like a separate issue that needs to be solved first.
